### PR TITLE
removed redundant quotation marks

### DIFF
--- a/deploy.bat
+++ b/deploy.bat
@@ -15,8 +15,8 @@ SET MSBUILD="%ProgramFiles(x86)%\MSBuild\14.0\Bin\MSBuild.exe"
 IF NOT EXIST %MSBUILD% SET MSBUILD="%ProgramFiles(x86)%\MSBuild\12.0\Bin\MSBuild.exe"
 IF NOT EXIST %MSBUILD% SET MSBUILD="%SystemRoot%\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe"
 
-"%MSBUILD%" %SOURCEDIR%\AutoTest.VS.RiskClassifier\RiskClassifier.sln /property:OutDir=%BINARYDIR%\;Configuration=Release /target:rebuild
-"%MSBUILD%" %SOURCEDIR%\AutoTestExtensions.sln /property:OutDir=%BINARYDIR%\;Configuration=Release /target:rebuild
+%MSBUILD% %SOURCEDIR%\AutoTest.VS.RiskClassifier\RiskClassifier.sln /property:OutDir=%BINARYDIR%\;Configuration=Release /target:rebuild
+%MSBUILD% %SOURCEDIR%\AutoTestExtensions.sln /property:OutDir=%BINARYDIR%\;Configuration=Release /target:rebuild
 
 IF NOT EXIST %DEPLOYDIR% (
   mkdir %DEPLOYDIR%


### PR DESCRIPTION
On windows: double use of quotation marks let the batch build fail
